### PR TITLE
Add check for stayArmed to support partitions where it is not configured

### DIFF
--- a/custom_components/ids_hyyp/alarm_control_panel.py
+++ b/custom_components/ids_hyyp/alarm_control_panel.py
@@ -85,7 +85,7 @@ class HyypAlarm(HyypPartitionEntity, AlarmControlPanelEntity):
             return STATE_ALARM_TRIGGERED
 
         if self.partition_data["armed"]:
-            if self.partition_data["stayArmed"]:
+            if "stayArmed" in self.partition_data and self.partition_data["stayArmed"]:
                 return STATE_ALARM_ARMED_HOME
 
             return STATE_ALARM_ARMED_AWAY


### PR DESCRIPTION
Some partitions may not have a stay profile configured.  When this is the case an exception is generated in the code and the arm/disarm state is not correctly reflected.

```
2022-11-30 17:09:28.351 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 151, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 283, in _async_refresh
    self.async_update_listeners()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 110, in async_update_listeners
    update_callback()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 348, in _handle_coordinator_update
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 545, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 583, in _async_write_ha_state
    state = self._stringify_state(available)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 551, in _stringify_state
    if (state := self.state) is None:
  File "/config/custom_components/ids_hyyp/alarm_control_panel.py", line 88, in state
    if "stayArmed" in self.partition_data:
KeyError: 'stayArmed'
```